### PR TITLE
Configurable lock duration

### DIFF
--- a/src/store/driver/filesystem_test.go
+++ b/src/store/driver/filesystem_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 var testConf config.Config
-
+var testLogDuration = util.ToMillisDuration(50)
 var testLog = util.NewLogger(util.LogLevelDebug, os.Stderr)
 
 // test that CreateAutoIndex creates a folder
@@ -21,7 +21,7 @@ func TestFSCreateAutoIndex(t *testing.T) {
 
 	defer os.RemoveAll(dirName)
 
-	fsd, err := driver.NewFilesystemDriver(dirName, ".kb", testLog)
+	fsd, err := driver.NewFilesystemDriver(dirName, ".kb", testLogDuration, testLog)
 	util.Ok(t, err)
 
 	indexName := "test_index"
@@ -41,7 +41,7 @@ func TestFSCreateMapIndex(t *testing.T) {
 
 	defer os.RemoveAll(dirName)
 
-	fsd, err := driver.NewFilesystemDriver(dirName, ".kb", testLog)
+	fsd, err := driver.NewFilesystemDriver(dirName, ".kb", testLogDuration, testLog)
 	util.Ok(t, err)
 
 	indexName := "test_index"
@@ -57,7 +57,7 @@ func TestFSCreateMapIndex(t *testing.T) {
 func TestFSNewFilesystemDriver(t *testing.T) {
 	dirName := "test_data"
 
-	_, err := driver.NewFilesystemDriver(dirName, ".kb", testLog)
+	_, err := driver.NewFilesystemDriver(dirName, ".kb", testLogDuration, testLog)
 	if err == nil {
 		t.Logf("attempting to instantiate filesystem driver on missing directory %s should fail", dirName)
 		t.FailNow()
@@ -68,7 +68,7 @@ func TestFSNewFilesystemDriver(t *testing.T) {
 
 	defer os.RemoveAll(dirName)
 
-	_, err = driver.NewFilesystemDriver(dirName, ".kb", testLog)
+	_, err = driver.NewFilesystemDriver(dirName, ".kb", testLogDuration, testLog)
 	util.Ok(t, err)
 }
 
@@ -80,7 +80,7 @@ func TestFSWritePageReadPage(t *testing.T) {
 
 	defer os.RemoveAll(dirName)
 
-	fsd, err := driver.NewFilesystemDriver(dirName, ".kb", testLog)
+	fsd, err := driver.NewFilesystemDriver(dirName, ".kb", testLogDuration, testLog)
 	util.Ok(t, err)
 
 	indexName := "test_index"
@@ -115,7 +115,7 @@ func TestFSWriteMapPageReadMapPage(t *testing.T) {
 
 	defer os.RemoveAll(dirName)
 
-	fsd, err := driver.NewFilesystemDriver(dirName, ".kb", testLog)
+	fsd, err := driver.NewFilesystemDriver(dirName, ".kb", testLogDuration, testLog)
 	util.Ok(t, err)
 
 	indexName := "test_index"
@@ -150,7 +150,7 @@ func TestFSListPages(t *testing.T) {
 
 	defer os.RemoveAll(dirName)
 
-	fsd, err := driver.NewFilesystemDriver(dirName, ".kb", testLog)
+	fsd, err := driver.NewFilesystemDriver(dirName, ".kb", testLogDuration, testLog)
 	util.Ok(t, err)
 
 	indexName := "test_index"

--- a/src/store/driver/s3_test.go
+++ b/src/store/driver/s3_test.go
@@ -62,7 +62,7 @@ func TestNewBucketDriver(t *testing.T) {
 	accessKeyID, accessKeySecret, bucketName, err := getEnvCreds()
 	util.Ok(t, err)
 
-	_, err = driver.NewBucketDriver(pageExtension, bucketName, accessKeyID, accessKeySecret, "", testLog)
+	_, err = driver.NewBucketDriver(pageExtension, bucketName, accessKeyID, accessKeySecret, "", testLogDuration, testLog)
 	util.Ok(t, err)
 }
 
@@ -71,7 +71,7 @@ func TestBucketCreateAutoIndex(t *testing.T) {
 	accessKeyID, accessKeySecret, bucketName, err := getEnvCreds()
 	util.Ok(t, err)
 
-	bd, err := driver.NewBucketDriver(pageExtension, bucketName, accessKeyID, accessKeySecret, "", testLog)
+	bd, err := driver.NewBucketDriver(pageExtension, bucketName, accessKeyID, accessKeySecret, "", testLogDuration, testLog)
 	util.Ok(t, err)
 
 	indexName := "test_index"
@@ -95,7 +95,7 @@ func TestBucketCreateMapIndex(t *testing.T) {
 	accessKeyID, accessKeySecret, bucketName, err := getEnvCreds()
 	util.Ok(t, err)
 
-	bd, err := driver.NewBucketDriver(pageExtension, bucketName, accessKeyID, accessKeySecret, "", testLog)
+	bd, err := driver.NewBucketDriver(pageExtension, bucketName, accessKeyID, accessKeySecret, "", testLogDuration, testLog)
 	util.Ok(t, err)
 
 	indexName := "test_index"
@@ -120,7 +120,7 @@ func TestBucketWritePageReadPage(t *testing.T) {
 	accessKeyID, accessKeySecret, bucketName, err := getEnvCreds()
 	util.Ok(t, err)
 
-	bd, err := driver.NewBucketDriver(pageExtension, bucketName, accessKeyID, accessKeySecret, "", testLog)
+	bd, err := driver.NewBucketDriver(pageExtension, bucketName, accessKeyID, accessKeySecret, "", testLogDuration, testLog)
 	util.Ok(t, err)
 
 	indexName := "test_index"

--- a/src/util/time.go
+++ b/src/util/time.go
@@ -19,3 +19,8 @@ func ParseMillisString(millis string) (time.Time, error) {
 
 	return time.Unix(0, msInt*int64(time.Millisecond)), nil
 }
+
+// ToMillisDuration turn an int64 millisecond duration into time.Duration
+func ToMillisDuration(millis int64) time.Duration {
+	return (time.Duration(millis) * time.Millisecond)
+}


### PR DESCRIPTION
Lock duration configured via environment and passed to storage drivers on instantiation instead of being hardcoded

resolves #3 