### PR TITLE
fixing newline handling in custom encoding format

### DIFF
--- a/src/store/driver/filesystem.go
+++ b/src/store/driver/filesystem.go
@@ -54,7 +54,7 @@ func (d FilesystemDriver) ReadPage(fileName string, indexName string, pageSize i
 		if err != nil {
 			return vals, orderedKeys, fmt.Errorf("pagefile parsing failed: %w", err)
 		}
-		vals[key] = value
+		vals[key] = unescapeNewlines(value)
 		orderedKeys = append(orderedKeys, key)
 		i++
 	}
@@ -83,7 +83,7 @@ func (d FilesystemDriver) ReadMapPage(fileName string, indexName string, pageSiz
 		if err != nil {
 			return vals, orderedKeys, fmt.Errorf("pagefile parsing failed: %w", err)
 		}
-		vals[key] = value
+		vals[key] = unescapeNewlines(value)
 		orderedKeys = append(orderedKeys, key)
 	}
 
@@ -113,7 +113,7 @@ func (d FilesystemDriver) WritePage(vals map[uint64]string, orderedKeys []uint64
 	}
 
 	for _, key := range orderedKeys {
-		line := fmt.Sprintf("%d:%s\n", key, vals[key])
+		line := fmt.Sprintf("%d:%s\n", key, escapeNewlines(vals[key]))
 		_, err = file.Write([]byte(line))
 		if err != nil {
 			return err
@@ -150,7 +150,7 @@ func (d FilesystemDriver) WriteMapPage(vals map[string]string, orderedKeys []str
 	}
 
 	for _, key := range orderedKeys {
-		line := fmt.Sprintf("%s:%s\n", key, vals[key])
+		line := fmt.Sprintf("%s:%s\n", key, escapeNewlines(vals[key]))
 		_, err = file.Write([]byte(line))
 		if err != nil {
 			return fmt.Errorf("writing line to map index file '%s' in index '%s' failed: %w", fileName, indexName, err)

--- a/src/store/driver/serialize.go
+++ b/src/store/driver/serialize.go
@@ -2,9 +2,7 @@ package driver
 
 import (
 	"fmt"
-	"io"
 	"strconv"
-	"strings"
 )
 
 // StringToKeyValue converts a line of text to a key-value pair used to read a page file
@@ -45,26 +43,4 @@ func SplitOnFirst(str string, split rune) ([]string, error) {
 	}
 	return []string{}, fmt.Errorf("provided string '%s' does not contain split character '%v'", str, split)
 
-}
-
-// NewPageReader constructs a page reader for an auto index page
-func NewPageReader(vals map[uint64]string, orderedKeys []uint64) io.Reader {
-	var body string
-	for _, key := range orderedKeys {
-		line := fmt.Sprintf("%d:%s\n", key, vals[key])
-		body += line
-	}
-
-	return strings.NewReader(body)
-}
-
-// NewMapPageReader constructs a page reader for a map page
-func NewMapPageReader(vals map[string]string, orderedKeys []string) io.Reader {
-	var body string
-	for _, key := range orderedKeys {
-		line := fmt.Sprintf("%s:%s\n", key, vals[key])
-		body += line
-	}
-
-	return strings.NewReader(body)
 }

--- a/src/store/driver/util.go
+++ b/src/store/driver/util.go
@@ -25,3 +25,15 @@ func sortFileNames(fileNames []string, fileExtension string) []string {
 	})
 	return fileNames
 }
+
+func escapeNewlines(in string) string {
+	out := strings.ReplaceAll(in, "\r", `\\r`)
+	out = strings.ReplaceAll(out, "\n", `\\n`)
+	return out
+}
+
+func unescapeNewlines(in string) string {
+	out := strings.ReplaceAll(in, `\\r`, `\r`)
+	out = strings.ReplaceAll(out, `\\n`, `\n`)
+	return out
+}


### PR DESCRIPTION
strings with newlines can be effectively stored in the custom encoding format now